### PR TITLE
Add `tailvalue` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Username: AmazonianChicken@example.com
 
 `pass tailedit <password file>` opens the password file in the editor omitting the first line. When saving the first line is prepended.
 
+## pass tailvalue
+
+`pass tailvalue <password file> <key>` displays the "value" associated with `<key>` from the specified password file. This allows discretely retrieving values of the meta data.
+
+```
+$ pass tailvalue <password file> Username
+AmazonianChicken@example.com
+```
+
+
 ## Installation
 
 - Enable password-store extensions by setting ``PASSWORD_STORE_ENABLE_EXTENSIONS=true``

--- a/src/tailvalue.bash
+++ b/src/tailvalue.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+local path="$1"
+local key="$2"
+local passfile="$PREFIX/$path.gpg"
+check_sneaky_paths "$path"
+
+if [[ -f $passfile ]]; then
+    $GPG -d "${GPG_OPTS[@]}" "$passfile" \
+        | tail -n +2 \
+        | grep "^$key:" \
+        | cut -d: -f2 \
+        | sed -e 's/^[ \t]*//' \
+        || exit $?
+elif [[ -z $path ]]; then
+    die ""
+else
+    die "Error: $path is not in the password store."
+fi


### PR DESCRIPTION
## pass tailvalue

`pass tailvalue <password file> <key>` displays the "value" associated with `<key>` from the specified password file. This allows discretely retrieving values of the meta data.

```
$ pass tailvalue <password file> Username
AmazonianChicken@example.com
```
