### PR TITLE
add tailclip command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ install:
 	@install -v -d "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/"
 	@install -v -m0755 src/tail.bash "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/tail.bash"
 	@install -v -m0755 src/tailedit.bash "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/tailedit.bash"
+	@install -v -m0755 src/tailclip.bash "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/tailclip.bash"
 	@install -v -d "$(DESTDIR)$(BASHCOMPDIR)/"
 	@install -v -m 644 completion/pass-tail.bash.completion  "$(DESTDIR)$(BASHCOMPDIR)/pass-tail"
 	@echo
@@ -30,11 +31,13 @@ uninstall:
 	@rm -vrf \
 		"$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/tail.bash" \
 		"$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/tailedit.bash" \
+		"$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/tailclip.bash" \
 		"$(DESTDIR)$(MANDIR)/man1/pass-tail.1" \
 		"$(DESTDIR)$(BASHCOMPDIR)/pass-tail"
 
 lint:
 	shellcheck -s bash src/tail.bash
 	shellcheck -s bash src/tailedit.bash
+	shellcheck -s bash src/tailclip.bash
 
 .PHONY: install uninstall lint

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Username: AmazonianChicken@example.com
 
 `pass tailedit <password file>` opens the password file in the editor omitting the first line. When saving the first line is prepended.
 
+## pass tailclip
+
+`pass tailclip <password file>` displays the whole password file except for the first line (like `pass tail`), but also copies the first line to the clipboard (like `pass show -c <password file>`).
+
 ## Installation
 
 - Enable password-store extensions by setting ``PASSWORD_STORE_ENABLE_EXTENSIONS=true``

--- a/completion/pass-tail.bash.completion
+++ b/completion/pass-tail.bash.completion
@@ -1,10 +1,15 @@
 PASSWORD_STORE_EXTENSION_COMMANDS+=(tail)
 PASSWORD_STORE_EXTENSION_COMMANDS+=(tailedit)
+PASSWORD_STORE_EXTENSION_COMMANDS+=(tailclip)
 
 __password_store_extension_complete_tail() {
     _pass_complete_entries 1
 }
 
 __password_store_extension_complete_tailedit() {
+    _pass_complete_entries 1
+}
+
+__password_store_extension_complete_tailclip() {
     _pass_complete_entries 1
 }

--- a/man/pass-extension-tail.1
+++ b/man/pass-extension-tail.1
@@ -15,6 +15,12 @@ tailedit
 [
 .I pass-name
 ]
+.br
+.B pass
+tailclip
+[
+.I pass-name
+]
 
 .SH DESCRIPTION
 
@@ -34,6 +40,9 @@ Display the whole password file except for the first line. This allows users to 
 .TP
 \fBtailedit\fP \fIpass-name\fP
 Open the password file in the editor omitting the first line. When saving the first line is prepended.
+.TP
+\fBtailclip\fP \fIpass-name\fP
+Display the whole password file except for the first line, and copy the first line to the clipboard. This is equivalent to the combination of \fBpass show -c\fP \fIpass-name\fP and \fBpass tail\fP \fIpass-name\fP
 
 .SH SEE ALSO
 .BR pass (1)

--- a/src/tailclip.bash
+++ b/src/tailclip.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+[[ $# -ne 1 ]] && die "Usage: $PROGRAM $COMMAND pass-name"
+
+path="${1%/}"
+
+# Get the full content
+content=$(cmd_show "$path")
+[[ $? -ne 0 ]] && die "$content"
+
+# Get the first line (password)
+password=$(echo "$content" | head -n 1)
+# Get the rest
+rest=$(echo "$content" | tail -n +2)
+
+# Display the rest
+echo "$rest"
+
+# Clip password
+clip "$password" "$path" >&2
+


### PR DESCRIPTION
tailclip command is meant to combine password copy to clipboard (pass show -c pass-name) and pass tail.

I frequently uses both commands sequentially to be able to paste a password and get additional information (user, notes, etc.)
Only tail content is push to stdout, so it can also be used to be piped and processed by another program.